### PR TITLE
Remove .DS_Store in the autoload helper

### DIFF
--- a/example/app/helpers/index.coffee
+++ b/example/app/helpers/index.coffee
@@ -3,6 +3,7 @@ fs = require 'fs'
 # Recursively require a folder’s files
 exports.autoload = autoload = (dir, app) ->
   fs.readdirSync(dir).forEach (file) ->
+    return if file is ".DS_Store"
     path = "#{dir}/#{file}"
     stats = fs.lstatSync(path)
 

--- a/lib/skeleton/template.coffee
+++ b/lib/skeleton/template.coffee
@@ -227,6 +227,7 @@ class Template
       # Recursively require a folder’s files
       exports.autoload = autoload = (dir, app) ->
         fs.readdirSync(dir).forEach (file) ->
+          return if file is ".DS_Store"
           path = "\#{dir}/\#{file}"
           stats = fs.lstatSync(path)
 


### PR DESCRIPTION
Prevent .DS_Store file to be loaded by the autoload helper
