### PR TITLE
Bumped version of Express and connect-assets

### DIFF
--- a/lib/skeleton/template.coffee
+++ b/lib/skeleton/template.coffee
@@ -20,8 +20,8 @@ class Template
           "name": "#{@appName}"
         , "version": "0.0.1"
         , "dependencies": {
-              "express": "3.0.0beta4"
-            , "connect-assets": "2.1.x"
+              "express": "3.0.3"
+            , "connect-assets": "2.3.3"
             #{this.getTemplateModule()}
             #{this.getCssModule()}
             #{this.getJsModule()}


### PR DESCRIPTION
I know we froze the Express 3 beta version because of a bug, but that seems to be fixed now.
